### PR TITLE
Add 'fail_on_commit' option to DevelopmentBranchCheckTask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 /composer.lock
 /.phpunit.cache/
+/.php-cs-fixer.cache

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ parameters:
         janvernieuwe_dev_branch:
             allowed_packages:
                 - roave/security-advisories # This is an example
+            fail_on_commit: false # Default true, allows for committingm wil still fail on CI
     extensions:
         - Janvernieuwe\DevBranchCheck\ExtensionLoader
 ```

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "~9.0 | ~10.0"
+        "phpunit/phpunit": "~9.0 | ~10.0",
+        "friendsofphp/php-cs-fixer": "^3.51"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,8 @@
          beStrictAboutCoverageMetadata="true"
          beStrictAboutOutputDuringTests="true"
          failOnRisky="true"
-         failOnWarning="true">
+         failOnWarning="true"
+         displayDetailsOnTestsThatTriggerWarnings="true">
     <testsuites>
         <testsuite name="default">
             <directory>tests</directory>


### PR DESCRIPTION
This change introduces a new 'fail_on_commit' option to the DevelopmentBranchCheckTask. This option, when set to false, allows tasks to fail in a non-blocking manner during a git pre-commit, while still failing as expected during a run context. The default value is set to true, maintaining the current behavior unless overridden.